### PR TITLE
Changed Rid1 value for WSP80 to avoid misidentification with JBC C245

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ My intention was to build the most universal soldering controller I can think of
 - Outer shell, PTC negative  and heater negative (white, black and brown wires) connected to EARTH, Vout1- and SENSEB
 - Heater positive (blue wire) connected to Vout1+
 - PTC positive (red wire) connected to SENSEA
-- 120ohm between ID and Vout1-
+- 330ohm between ID and Vout1- (WARNING: in FW version <= 1.0 this R value was 120 ohms)
 - 5.6k between ID and Vout2-
 
 ### 9. ERSA RT80:

--- a/software/front/US_Firmware.X/iron.c
+++ b/software/front/US_Firmware.X/iron.c
@@ -712,7 +712,7 @@ const t_IronPars Irons[] = {
 
     {
         0, 
-        {0x1803},
+        {0x180C},
         "WELLER WSP80            ",
         {
             {

--- a/software/front/US_Firmware.X/main.h
+++ b/software/front/US_Firmware.X/main.h
@@ -20,7 +20,7 @@ extern "C" {
 
 /*This will be visible in version menu*/
 #define VERSION_MAJOR   1
-#define VERSION_MINOR   0
+#define VERSION_MINOR   1
 
 typedef struct __PACKED{
     int HolderPresent:1;


### PR DESCRIPTION
We have observed a JBC C245 (Rid1=150 ohms, Rid2=same value as WSP80) being misidentified as WSP 80. 
This results in soldering tip becoming incandescent. 
To solve this safety issue I propose this breaking change.
Readme and minor version updated accordingly.